### PR TITLE
Refactor event handler to remove macros

### DIFF
--- a/Code/PigeonLib/Pigeon/Application.cpp
+++ b/Code/PigeonLib/Pigeon/Application.cpp
@@ -11,8 +11,6 @@
 
 #include <chrono>
 
-#define BIND_EVENT_FN(x) std::bind(&pig::Application::x, this, std::placeholders::_1)
-
 pig::U_Ptr<pig::Application> pig::Application::s_Instance = nullptr;
 
 pig::Application::~Application()
@@ -37,8 +35,8 @@ void pig::Application::OnEvent(pig::Event& e)
 	if (m_Data.m_Initialized)
 	{
 		pig::EventDispatcher dispatcher(e);
-		dispatcher.Dispatch<pig::WindowCloseEvent>(BIND_EVENT_FN(OnWindowClose));
-		dispatcher.Dispatch<pig::WindowResizeEvent>(BIND_EVENT_FN(OnWindowResize));
+		dispatcher.Dispatch<pig::WindowCloseEvent>(BindEventFn<&Application::OnWindowClose>());
+		dispatcher.Dispatch<pig::WindowResizeEvent>(BindEventFn<&Application::OnWindowResize>());
 
 		if (!m_Data.m_Minimized)
 		{
@@ -79,7 +77,7 @@ void pig::Application::Shutdown()
 void pig::Application::Init()
 {
 	m_Data.m_Window = std::move(Window::Create());
-	m_Data.m_Window->SetEventCallback(BIND_EVENT_FN(OnEvent));
+	m_Data.m_Window->SetEventCallback(BindEventFn<&Application::OnEvent>());
 	pig::Renderer::Init();
 	pig::Renderer2D::Init();
 	m_Data.m_ImGuiLayer = std::make_shared<ImGuiLayer>();

--- a/Code/PigeonLib/Pigeon/Application.cpp
+++ b/Code/PigeonLib/Pigeon/Application.cpp
@@ -34,8 +34,8 @@ void pig::Application::OnEvent(const pig::Event& e)
 {
 	if (m_Data.m_Initialized)
 	{
-		pig::EventDispatcher::Dispatch<pig::WindowCloseEvent>(e, pig::BindEventFn<&Application::OnWindowClose>(this));
-		pig::EventDispatcher::Dispatch<pig::WindowResizeEvent>(e, pig::BindEventFn<&Application::OnWindowResize>(this));
+		pig::EventDispatcher::Dispatch<pig::WindowCloseEvent>(e, pig::BindEventFn<&Application::OnWindowClose, Application>(this));
+		pig::EventDispatcher::Dispatch<pig::WindowResizeEvent>(e, pig::BindEventFn<&Application::OnWindowResize, Application>(this));
 
 		if (!m_Data.m_Minimized)
 		{

--- a/Code/PigeonLib/Pigeon/Application.cpp
+++ b/Code/PigeonLib/Pigeon/Application.cpp
@@ -30,13 +30,12 @@ void pig::Application::PushOverlay(pig::S_Ptr<pig::Layer> layer)
 	layer->OnAttach();
 }
 
-void pig::Application::OnEvent(pig::Event& e)
+void pig::Application::OnEvent(const pig::Event& e)
 {
 	if (m_Data.m_Initialized)
 	{
-		pig::EventDispatcher dispatcher(e);
-		dispatcher.Dispatch<pig::WindowCloseEvent>(pig::BindEventFn<&Application::OnWindowClose, Application>(this));
-		dispatcher.Dispatch<pig::WindowResizeEvent>(pig::BindEventFn<&Application::OnWindowResize, Application>(this));
+		pig::EventDispatcher::Dispatch<pig::WindowCloseEvent>(e, pig::BindEventFn<&Application::OnWindowClose>(this));
+		pig::EventDispatcher::Dispatch<pig::WindowResizeEvent>(e, pig::BindEventFn<&Application::OnWindowResize>(this));
 
 		if (!m_Data.m_Minimized)
 		{
@@ -110,14 +109,14 @@ void pig::Application::Update()
 	m_Data.m_Window->OnUpdate();
 }
 
-bool pig::Application::OnWindowClose(pig::WindowCloseEvent& e)
+bool pig::Application::OnWindowClose(const pig::WindowCloseEvent& e)
 {
 	pig::Renderer2D::Destroy();
 	m_Data.m_Running = false;
 	return false;
 }
 
-bool pig::Application::OnWindowResize(pig::WindowResizeEvent& e)
+bool pig::Application::OnWindowResize(const pig::WindowResizeEvent& e)
 {
 	if (e.GetWidth() == 0 || e.GetHeight() == 0)
 	{

--- a/Code/PigeonLib/Pigeon/Application.cpp
+++ b/Code/PigeonLib/Pigeon/Application.cpp
@@ -35,8 +35,8 @@ void pig::Application::OnEvent(pig::Event& e)
 	if (m_Data.m_Initialized)
 	{
 		pig::EventDispatcher dispatcher(e);
-		dispatcher.Dispatch<pig::WindowCloseEvent>(BindEventFn<&Application::OnWindowClose>());
-		dispatcher.Dispatch<pig::WindowResizeEvent>(BindEventFn<&Application::OnWindowResize>());
+		dispatcher.Dispatch<pig::WindowCloseEvent>(pig::BindEventFn<&Application::OnWindowClose, Application>(this));
+		dispatcher.Dispatch<pig::WindowResizeEvent>(pig::BindEventFn<&Application::OnWindowResize, Application>(this));
 
 		if (!m_Data.m_Minimized)
 		{
@@ -77,7 +77,7 @@ void pig::Application::Shutdown()
 void pig::Application::Init()
 {
 	m_Data.m_Window = std::move(Window::Create());
-	m_Data.m_Window->SetEventCallback(BindEventFn<&Application::OnEvent>());
+	m_Data.m_Window->SetEventCallback(pig::BindEventFn<&Application::OnEvent, Application>(this));
 	pig::Renderer::Init();
 	pig::Renderer2D::Init();
 	m_Data.m_ImGuiLayer = std::make_shared<ImGuiLayer>();

--- a/Code/PigeonLib/Pigeon/Application.cpp
+++ b/Code/PigeonLib/Pigeon/Application.cpp
@@ -39,11 +39,13 @@ void pig::Application::OnEvent(const pig::Event& e)
 
 		if (!m_Data.m_Minimized)
 		{
-			for (auto it = m_Data.m_LayerStack.end(); it != m_Data.m_LayerStack.begin(); )
+			for (auto it = m_Data.m_LayerStack.rbegin(); it != m_Data.m_LayerStack.rend(); it++)
 			{
-				(*--it)->OnEvent(e);
-				if (e.Handled)
+				bool handled = (*it)->OnEvent(e);
+				if (handled)
+				{
 					break;
+				}
 			}
 		}
 	}

--- a/Code/PigeonLib/Pigeon/Application.h
+++ b/Code/PigeonLib/Pigeon/Application.h
@@ -44,6 +44,15 @@ namespace pig
 			return s_Instance->Get();
 		}
 
+		template<auto EventFn>
+		auto BindEventFn() 
+		{
+			return [this](auto&&... args) -> decltype(auto) 
+			{
+				return std::invoke(EventFn, this, std::forward<decltype(args)>(args)...);
+			};
+		}
+
 		Application() = default;
 		virtual ~Application();
 

--- a/Code/PigeonLib/Pigeon/Application.h
+++ b/Code/PigeonLib/Pigeon/Application.h
@@ -53,7 +53,7 @@ namespace pig
 #else
 		void Run();
 #endif
-		void OnEvent(Event& e);
+		void OnEvent(const Event& e);
 		void PushLayer(pig::S_Ptr<Layer> layer);
 		void PushOverlay(pig::S_Ptr<Layer> layer);
 
@@ -66,8 +66,8 @@ namespace pig
 
 		void Update();
 
-		bool OnWindowClose(WindowCloseEvent& e);
-		bool OnWindowResize(WindowResizeEvent& e);
+		bool OnWindowClose(const WindowCloseEvent& e);
+		bool OnWindowResize(const WindowResizeEvent& e);
 
 		Data m_Data;
 	private:

--- a/Code/PigeonLib/Pigeon/Application.h
+++ b/Code/PigeonLib/Pigeon/Application.h
@@ -44,15 +44,6 @@ namespace pig
 			return s_Instance->Get();
 		}
 
-		template<auto EventFn>
-		auto BindEventFn() 
-		{
-			return [this](auto&&... args) -> decltype(auto) 
-			{
-				return std::invoke(EventFn, this, std::forward<decltype(args)>(args)...);
-			};
-		}
-
 		Application() = default;
 		virtual ~Application();
 

--- a/Code/PigeonLib/Pigeon/Core.h
+++ b/Code/PigeonLib/Pigeon/Core.h
@@ -69,17 +69,9 @@ namespace pig
 	template <auto EventFn, typename EventHandler>
 	auto BindEventFn(EventHandler* handler) 
 	{
-		return [handler](const auto& event) -> decltype(auto)
+		return [handler](auto&&... args) -> decltype(auto)
 		{
-			if constexpr (std::is_same_v<decltype(std::invoke(EventFn, handler, event)), void>)
-			{
-				std::invoke(EventFn, handler, event);
-				return;
-			}
-			else 
-			{
-				return std::invoke(EventFn, handler, event);
-			}
+			return std::invoke(EventFn, handler, std::forward<decltype(args)>(args)...);
 		};
 	}
 	

--- a/Code/PigeonLib/Pigeon/Core.h
+++ b/Code/PigeonLib/Pigeon/Core.h
@@ -25,8 +25,6 @@
 
 #define BIT(x) (1 << x)
 
-#define PG_BIND_EVENT_FN(fn) std::bind(&fn, this, std::placeholders::_1)
-
 namespace pig
 {
 	template<typename T, typename Deleter = std::default_delete<T>>
@@ -67,5 +65,22 @@ namespace pig
 
 	template<typename T>
 	using S_Ptr = std::shared_ptr<T>;
+
+	template <auto EventFn, typename EventHandler>
+	auto BindEventFn(EventHandler* handler)
+	{
+		return [handler](auto& event) -> decltype(auto)
+		{
+			if constexpr (std::is_same_v<decltype(std::invoke(EventFn, handler, event)), void>)
+			{
+				std::invoke(EventFn, handler, event);
+				return;
+			}
+			else
+			{
+				return std::invoke(EventFn, handler, event);
+			}
+		};
+	}
 	
 }

--- a/Code/PigeonLib/Pigeon/Core.h
+++ b/Code/PigeonLib/Pigeon/Core.h
@@ -67,16 +67,16 @@ namespace pig
 	using S_Ptr = std::shared_ptr<T>;
 
 	template <auto EventFn, typename EventHandler>
-	auto BindEventFn(EventHandler* handler)
+	auto BindEventFn(EventHandler* handler) 
 	{
-		return [handler](auto& event) -> decltype(auto)
+		return [handler](const auto& event) -> decltype(auto)
 		{
 			if constexpr (std::is_same_v<decltype(std::invoke(EventFn, handler, event)), void>)
 			{
 				std::invoke(EventFn, handler, event);
 				return;
 			}
-			else
+			else 
 			{
 				return std::invoke(EventFn, handler, event);
 			}

--- a/Code/PigeonLib/Pigeon/Events/ApplicationEvent.h
+++ b/Code/PigeonLib/Pigeon/Events/ApplicationEvent.h
@@ -4,7 +4,9 @@
 
 namespace pig {
 
-	class PIGEON_API WindowResizeEvent : public Event
+	class PIGEON_API WindowResizeEvent : 
+		public EventClassCategory<EventCategoryApplication>,
+		public EventClassType<EventType::WindowResize>
 	{
 	public:
 		WindowResizeEvent(unsigned int width, unsigned int height)
@@ -20,19 +22,16 @@ namespace pig {
 			return ss.str();
 		}
 
-		EVENT_CLASS_TYPE(WindowResize)
-		EVENT_CLASS_CATEGORY(EventCategoryApplication)
 	private:
 		unsigned int m_Width, m_Height;
 	};
 
-	class PIGEON_API WindowCloseEvent : public Event
+	class PIGEON_API WindowCloseEvent : 
+		public EventClassType<EventType::WindowClose>,
+		public EventClassCategory<EventCategoryApplication>
 	{
 	public:
 		WindowCloseEvent() {}
-
-		EVENT_CLASS_TYPE(WindowClose)
-		EVENT_CLASS_CATEGORY(EventCategoryApplication)
 	};
 
 	/*class PIGEON_API AppTickEvent : public Event

--- a/Code/PigeonLib/Pigeon/Events/Event.h
+++ b/Code/PigeonLib/Pigeon/Events/Event.h
@@ -52,26 +52,15 @@ namespace pig {
 
 	class EventDispatcher
 	{
-		template<typename T>
-		using EventFn = std::function<bool(T&)>;
 	public:
-		EventDispatcher(Event& event)
-			: m_Event(event)
-		{
-		}
-
 		template<typename T>
-		bool Dispatch(EventFn<T> func)
+		static bool Dispatch(const Event& event, std::function<bool(const T&)> func) 
 		{
-			if (m_Event.GetEventType() == T::GetStaticType())
+			if (event.GetEventType() == T::GetStaticType()) 
 			{
-				m_Event.Handled = func(*(T*)&m_Event);
-				return true;
+				return func(static_cast<const T&>(event));
 			}
-			return false;
 		}
-	private:
-		Event& m_Event;
 	};
 
 	inline std::ostream& operator<<(std::ostream& os, const Event& e)

--- a/Code/PigeonLib/Pigeon/Events/Event.h
+++ b/Code/PigeonLib/Pigeon/Events/Event.h
@@ -46,8 +46,6 @@ namespace pig {
 		{
 			return GetCategoryFlags() & category;
 		}
-
-		bool Handled = false;
 	};
 
 	class EventDispatcher
@@ -60,6 +58,7 @@ namespace pig {
 			{
 				return func(static_cast<const T&>(event));
 			}
+			return false;
 		}
 	};
 

--- a/Code/PigeonLib/Pigeon/Events/KeyEvent.h
+++ b/Code/PigeonLib/Pigeon/Events/KeyEvent.h
@@ -4,12 +4,12 @@
 
 namespace pig {
 
-	class PIGEON_API KeyEvent : public Event
+	class PIGEON_API KeyEvent :
+		public EventClassCategory< EventCategoryKeyboard | EventCategoryInput >
 	{
 	public:
 		inline int GetKeyCode() const { return m_KeyCode; }
 
-		EVENT_CLASS_CATEGORY(EventCategoryKeyboard | EventCategoryInput)
 	protected:
 		KeyEvent(int keycode)
 			: m_KeyCode(keycode) {}
@@ -17,7 +17,9 @@ namespace pig {
 		int m_KeyCode;
 	};
 
-	class PIGEON_API KeyPressedEvent : public KeyEvent
+	class PIGEON_API KeyPressedEvent : 
+		public KeyEvent,
+		public EventClassType<EventType::KeyPressed>
 	{
 	public:
 		KeyPressedEvent(int keycode, int repeatCount)
@@ -32,12 +34,13 @@ namespace pig {
 			return ss.str();
 		}
 
-		EVENT_CLASS_TYPE(KeyPressed)
 	private:
 		int m_RepeatCount;
 	};
 
-	class PIGEON_API KeyReleasedEvent : public KeyEvent
+	class PIGEON_API KeyReleasedEvent : 
+		public KeyEvent,
+		public EventClassType<EventType::KeyReleased>
 	{
 	public:
 		KeyReleasedEvent(int keycode)
@@ -49,11 +52,11 @@ namespace pig {
 			ss << "KeyReleasedEvent: " << m_KeyCode;
 			return ss.str();
 		}
-
-		EVENT_CLASS_TYPE(KeyReleased)
 	};
 
-	class PIGEON_API KeyTypedEvent : public KeyEvent
+	class PIGEON_API KeyTypedEvent : 
+		public KeyEvent,
+		public EventClassType<EventType::KeyTyped>
 	{
 	public:
 		KeyTypedEvent(int keycode)
@@ -65,7 +68,5 @@ namespace pig {
 			ss << "KeyTypedEvent: " << m_KeyCode;
 			return ss.str();
 		}
-
-		EVENT_CLASS_TYPE(KeyTyped)
 	};
 }

--- a/Code/PigeonLib/Pigeon/Events/MouseEvent.h
+++ b/Code/PigeonLib/Pigeon/Events/MouseEvent.h
@@ -4,7 +4,9 @@
 
 namespace pig {
 
-	class PIGEON_API MouseMovedEvent : public Event
+	class PIGEON_API MouseMovedEvent : 
+		public EventClassCategory<EventCategoryMouse | EventCategoryInput>,
+		public EventClassType<EventType::MouseMoved>
 	{
 	public:
 		MouseMovedEvent(float x, float y)
@@ -20,13 +22,13 @@ namespace pig {
 			return ss.str();
 		}
 
-		EVENT_CLASS_TYPE(MouseMoved)
-		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
 	private:
 		float m_MouseX, m_MouseY;
 	};
 
-	class PIGEON_API MouseScrolledEvent : public Event
+	class PIGEON_API MouseScrolledEvent : 
+		public EventClassCategory<EventCategoryMouse | EventCategoryInput>,
+		public EventClassType<EventType::MouseScrolled>
 	{
 	public:
 		MouseScrolledEvent(float xOffset, float yOffset)
@@ -42,18 +44,16 @@ namespace pig {
 			return ss.str();
 		}
 
-		EVENT_CLASS_TYPE(MouseScrolled)
-		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
 	private:
 		float m_XOffset, m_YOffset;
 	};
 
-	class PIGEON_API MouseButtonEvent : public Event
+	class PIGEON_API MouseButtonEvent : 
+		public EventClassCategory< EventCategoryMouse | EventCategoryInput | EventCategoryMouseButton >
 	{
 	public:
 		inline int GetMouseButton() const { return m_Button; }
 
-		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput | EventCategoryMouseButton)
 	protected:
 		MouseButtonEvent(int button)
 			: m_Button(button) {}
@@ -61,7 +61,9 @@ namespace pig {
 		int m_Button;
 	};
 
-	class PIGEON_API MouseButtonPressedEvent : public MouseButtonEvent
+	class PIGEON_API MouseButtonPressedEvent : 
+		public MouseButtonEvent,
+		public EventClassType<EventType::MouseButtonPressed>
 	{
 	public:
 		MouseButtonPressedEvent(int button)
@@ -73,11 +75,11 @@ namespace pig {
 			ss << "MouseButtonPressedEvent: " << m_Button;
 			return ss.str();
 		}
-
-		EVENT_CLASS_TYPE(MouseButtonPressed)
 	};
 
-	class PIGEON_API MouseButtonReleasedEvent : public MouseButtonEvent
+	class PIGEON_API MouseButtonReleasedEvent : 
+		public MouseButtonEvent, 
+		public EventClassType<EventType::MouseButtonReleased>
 	{
 	public:
 		MouseButtonReleasedEvent(int button)
@@ -89,8 +91,6 @@ namespace pig {
 			ss << "MouseButtonReleasedEvent: " << m_Button;
 			return ss.str();
 		}
-
-		EVENT_CLASS_TYPE(MouseButtonReleased)
 	};
 
 }

--- a/Code/PigeonLib/Pigeon/Layer.h
+++ b/Code/PigeonLib/Pigeon/Layer.h
@@ -16,7 +16,7 @@ namespace pig
 		virtual void OnDetach() {}
 		virtual void OnUpdate(Timestep ts) {}
 		virtual void OnImGuiRender() {}
-		virtual void OnEvent(Event& event) {}
+		virtual void OnEvent(const Event& event) {}
 
 		virtual void Begin() {};
 		virtual void End() {};

--- a/Code/PigeonLib/Pigeon/Layer.h
+++ b/Code/PigeonLib/Pigeon/Layer.h
@@ -16,7 +16,7 @@ namespace pig
 		virtual void OnDetach() {}
 		virtual void OnUpdate(Timestep ts) {}
 		virtual void OnImGuiRender() {}
-		virtual void OnEvent(const Event& event) {}
+		virtual bool OnEvent(const Event& event) { return false; }
 
 		virtual void Begin() {};
 		virtual void End() {};

--- a/Code/PigeonLib/Pigeon/LayerStack.h
+++ b/Code/PigeonLib/Pigeon/LayerStack.h
@@ -31,6 +31,9 @@ namespace pig
 
 		std::vector<pig::S_Ptr<Layer>>::iterator begin() { return m_Data.m_Layers.begin(); }
 		std::vector<pig::S_Ptr<Layer>>::iterator end() { return m_Data.m_Layers.end(); }
+
+		std::vector<pig::S_Ptr<Layer>>::reverse_iterator rbegin() { return m_Data.m_Layers.rbegin(); }
+		std::vector<pig::S_Ptr<Layer>>::reverse_iterator rend() { return m_Data.m_Layers.rend(); }
 	private:
 		Data m_Data;
 	};

--- a/Code/PigeonLib/Pigeon/OrthographicCameraController.cpp
+++ b/Code/PigeonLib/Pigeon/OrthographicCameraController.cpp
@@ -41,8 +41,8 @@ void pig::OrthographicCameraController::OnUpdate(Timestep ts)
 void pig::OrthographicCameraController::OnEvent(Event& e)
 {
 	EventDispatcher dispatcher(e);
-	dispatcher.Dispatch<MouseScrolledEvent>(PG_BIND_EVENT_FN(OrthographicCameraController::OnMouseScrolled));
-	dispatcher.Dispatch<WindowResizeEvent>(PG_BIND_EVENT_FN(OrthographicCameraController::OnWindowResized));
+	dispatcher.Dispatch<MouseScrolledEvent>(pig::BindEventFn<&OrthographicCameraController::OnMouseScrolled, OrthographicCameraController>(this));
+	dispatcher.Dispatch<WindowResizeEvent>(pig::BindEventFn<&OrthographicCameraController::OnWindowResized, OrthographicCameraController>(this));
 }
 
 bool pig::OrthographicCameraController::OnMouseScrolled(MouseScrolledEvent& e)

--- a/Code/PigeonLib/Pigeon/OrthographicCameraController.cpp
+++ b/Code/PigeonLib/Pigeon/OrthographicCameraController.cpp
@@ -38,14 +38,13 @@ void pig::OrthographicCameraController::OnUpdate(Timestep ts)
 	m_Data.m_CameraTranslationSpeed = m_Data.m_ZoomLevel;
 }
 
-void pig::OrthographicCameraController::OnEvent(Event& e)
+void pig::OrthographicCameraController::OnEvent(const Event& e)
 {
-	EventDispatcher dispatcher(e);
-	dispatcher.Dispatch<MouseScrolledEvent>(pig::BindEventFn<&OrthographicCameraController::OnMouseScrolled, OrthographicCameraController>(this));
-	dispatcher.Dispatch<WindowResizeEvent>(pig::BindEventFn<&OrthographicCameraController::OnWindowResized, OrthographicCameraController>(this));
+	pig::EventDispatcher::Dispatch<MouseScrolledEvent>(e, pig::BindEventFn<&OrthographicCameraController::OnMouseScrolled, OrthographicCameraController>(this));
+	pig::EventDispatcher::Dispatch<WindowResizeEvent>(e, pig::BindEventFn<&OrthographicCameraController::OnWindowResized, OrthographicCameraController>(this));
 }
 
-bool pig::OrthographicCameraController::OnMouseScrolled(MouseScrolledEvent& e)
+bool pig::OrthographicCameraController::OnMouseScrolled(const MouseScrolledEvent& e)
 {
 	m_Data.m_ZoomLevel -= e.GetYOffset() * 0.25f;
 	m_Data.m_ZoomLevel = std::max(m_Data.m_ZoomLevel, 0.25f);
@@ -53,7 +52,7 @@ bool pig::OrthographicCameraController::OnMouseScrolled(MouseScrolledEvent& e)
 	return false;
 }
 
-bool pig::OrthographicCameraController::OnWindowResized(WindowResizeEvent& e)
+bool pig::OrthographicCameraController::OnWindowResized(const WindowResizeEvent& e)
 {
 	m_Data.m_AspectRatio = (float)e.GetWidth() / (float)e.GetHeight();
 	m_Data.m_Camera.SetProjection(-m_Data.m_AspectRatio * m_Data.m_ZoomLevel, m_Data.m_AspectRatio * m_Data.m_ZoomLevel, -m_Data.m_ZoomLevel, m_Data.m_ZoomLevel);

--- a/Code/PigeonLib/Pigeon/OrthographicCameraController.cpp
+++ b/Code/PigeonLib/Pigeon/OrthographicCameraController.cpp
@@ -38,10 +38,11 @@ void pig::OrthographicCameraController::OnUpdate(Timestep ts)
 	m_Data.m_CameraTranslationSpeed = m_Data.m_ZoomLevel;
 }
 
-void pig::OrthographicCameraController::OnEvent(const Event& e)
+bool pig::OrthographicCameraController::OnEvent(const Event& e)
 {
-	pig::EventDispatcher::Dispatch<MouseScrolledEvent>(e, pig::BindEventFn<&OrthographicCameraController::OnMouseScrolled, OrthographicCameraController>(this));
-	pig::EventDispatcher::Dispatch<WindowResizeEvent>(e, pig::BindEventFn<&OrthographicCameraController::OnWindowResized, OrthographicCameraController>(this));
+	return
+		pig::EventDispatcher::Dispatch<MouseScrolledEvent>(e, pig::BindEventFn<&OrthographicCameraController::OnMouseScrolled, OrthographicCameraController>(this)) ||
+		pig::EventDispatcher::Dispatch<WindowResizeEvent>(e, pig::BindEventFn<&OrthographicCameraController::OnWindowResized, OrthographicCameraController>(this));
 }
 
 bool pig::OrthographicCameraController::OnMouseScrolled(const MouseScrolledEvent& e)

--- a/Code/PigeonLib/Pigeon/OrthographicCameraController.h
+++ b/Code/PigeonLib/Pigeon/OrthographicCameraController.h
@@ -32,7 +32,7 @@ namespace pig
 #endif
 
 		void OnUpdate(Timestep ts);
-		void OnEvent(const Event& e);
+		bool OnEvent(const Event& e);
 
 		const OrthographicCamera& GetCamera() const { return m_Data.m_Camera; }
 

--- a/Code/PigeonLib/Pigeon/OrthographicCameraController.h
+++ b/Code/PigeonLib/Pigeon/OrthographicCameraController.h
@@ -32,7 +32,7 @@ namespace pig
 #endif
 
 		void OnUpdate(Timestep ts);
-		void OnEvent(Event& e);
+		void OnEvent(const Event& e);
 
 		const OrthographicCamera& GetCamera() const { return m_Data.m_Camera; }
 
@@ -40,8 +40,8 @@ namespace pig
 		void SetZoomLevel(float level) { m_Data.m_ZoomLevel = level; }
 
 	private:
-		bool OnMouseScrolled(MouseScrolledEvent& e);
-		bool OnWindowResized(WindowResizeEvent& e);
+		bool OnMouseScrolled(const MouseScrolledEvent& e);
+		bool OnWindowResized(const WindowResizeEvent& e);
 	private:
 		Data m_Data;
 	};

--- a/Code/SandboxApp/Sandbox2D.cpp
+++ b/Code/SandboxApp/Sandbox2D.cpp
@@ -43,7 +43,7 @@ void sbx::Sandbox2D::OnImGuiRender()
 	ImGui::End();
 }
 
-void sbx::Sandbox2D::OnEvent(pig::Event& event)
+void sbx::Sandbox2D::OnEvent(const pig::Event& event)
 {
 	m_CameraController.OnEvent(event);
 }

--- a/Code/SandboxApp/Sandbox2D.cpp
+++ b/Code/SandboxApp/Sandbox2D.cpp
@@ -43,7 +43,7 @@ void sbx::Sandbox2D::OnImGuiRender()
 	ImGui::End();
 }
 
-void sbx::Sandbox2D::OnEvent(const pig::Event& event)
+bool sbx::Sandbox2D::OnEvent(const pig::Event& event)
 {
-	m_CameraController.OnEvent(event);
+	return m_CameraController.OnEvent(event);
 }

--- a/Code/SandboxApp/Sandbox2D.h
+++ b/Code/SandboxApp/Sandbox2D.h
@@ -17,7 +17,7 @@ namespace sbx
 		void OnUpdate(pig::Timestep ts) override;
 
 		virtual void OnImGuiRender() override;
-		void OnEvent(pig::Event& event) override;
+		void OnEvent(const pig::Event& event) override;
 
 	private:
 

--- a/Code/SandboxApp/Sandbox2D.h
+++ b/Code/SandboxApp/Sandbox2D.h
@@ -17,7 +17,7 @@ namespace sbx
 		void OnUpdate(pig::Timestep ts) override;
 
 		virtual void OnImGuiRender() override;
-		void OnEvent(const pig::Event& event) override;
+		bool OnEvent(const pig::Event& event) override;
 
 	private:
 

--- a/Code/SandboxApp/SandboxApp.cpp
+++ b/Code/SandboxApp/SandboxApp.cpp
@@ -107,7 +107,7 @@ namespace
 			ImGui::End();
 		}
 
-		void OnEvent(pig::Event& event) override
+		void OnEvent(const pig::Event& event) override
 		{
 			m_CameraController.OnEvent(event);
 			/*if (event.GetEventType() == pigeon::EventType::KeyPressed)

--- a/Code/SandboxApp/SandboxApp.cpp
+++ b/Code/SandboxApp/SandboxApp.cpp
@@ -107,9 +107,9 @@ namespace
 			ImGui::End();
 		}
 
-		void OnEvent(const pig::Event& event) override
+		bool OnEvent(const pig::Event& event) override
 		{
-			m_CameraController.OnEvent(event);
+			return m_CameraController.OnEvent(event);
 			/*if (event.GetEventType() == pigeon::EventType::KeyPressed)
 			{
 				pigeon::KeyPressedEvent& e = (pigeon::KeyPressedEvent&)event;

--- a/Code/UT/UT_Layers/UT_EventsTest.cpp
+++ b/Code/UT/UT_Layers/UT_EventsTest.cpp
@@ -33,33 +33,33 @@ namespace
 		return std::get<T>(eventResult);
 	}
 	
-	ExpectedEventResult StoreToVariant(pig::Event& ev)
+	ExpectedEventResult StoreToVariant(const pig::Event& ev)
 	{
-		if (auto e = dynamic_cast<pig::KeyPressedEvent*>(&ev)) {
+		if (auto e = dynamic_cast<const pig::KeyPressedEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::KeyReleasedEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::KeyReleasedEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::KeyTypedEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::KeyTypedEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::WindowResizeEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::WindowResizeEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::WindowCloseEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::WindowCloseEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::MouseMovedEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::MouseMovedEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::MouseScrolledEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::MouseScrolledEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::MouseButtonPressedEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::MouseButtonPressedEvent*>(&ev)) {
 			return *e;
 		}
-		else if (auto e = dynamic_cast<pig::MouseButtonReleasedEvent*>(&ev)) {
+		else if (auto e = dynamic_cast<const pig::MouseButtonReleasedEvent*>(&ev)) {
 			return *e;
 		}
 		else
@@ -81,9 +81,10 @@ namespace
 			m_ExpectedEvent = false;
 		}
 
-		void OnEvent(pig::Event& event) override
+		bool OnEvent(const pig::Event& event) override
 		{
 			m_ExpectedEvent = StoreToVariant(event);
+			return true;
 		}
 		ExpectedEventResult m_ExpectedEvent = false;
 	};

--- a/Code/UT/UT_Layers/UT_LayerPropagationTest.cpp
+++ b/Code/UT/UT_Layers/UT_LayerPropagationTest.cpp
@@ -23,14 +23,14 @@ namespace
 			m_ReceivedEvent = false;
 		}
 
-		void OnEvent(pig::Event& event) override
+		bool OnEvent(const pig::Event& event) override
 		{
-
 			//THIS IS TO TEST LAYER PROPAGATION
-			if (auto e = dynamic_cast<pig::KeyPressedEvent*>(&event)) {
+			if (auto e = dynamic_cast<const pig::KeyPressedEvent*>(&event)) {
 				m_ReceivedEvent = true;
-				event.Handled = true;
+				return true;
 			}
+			return false;
 		}
 		bool m_ReceivedEvent = false;
 	};
@@ -47,11 +47,12 @@ namespace
 			m_ReceivedEvent = false;
 		}
 
-		void OnEvent(pig::Event& event) override
+		bool OnEvent(const pig::Event& event) override
 		{
-			if (auto e = dynamic_cast<pig::KeyPressedEvent*>(&event)) {
+			if (auto e = dynamic_cast<const pig::KeyPressedEvent*>(&event)) {
 				m_ReceivedEvent = true;
 			}
+			return false;
 		}
 		bool m_ReceivedEvent = false;
 	};


### PR DESCRIPTION
+ Refactor macros `BIND_EVENT_FN` and `PG_BIND_EVENT_FN`  to function `pig::BindEventFn`
+ Refactor macros `EVENT_CLASS_CATEGORY` and `EVENT_CLASS_TYPE` to classes `EventClassType` and `EventClassCategory`
+ Add `const` to `pig::Event` usage (also removes redundant member `bool handled`)